### PR TITLE
Code for Issues 13(Hide/Show Filters) and 14(Black/White Filter Toggle)

### DIFF
--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -3,10 +3,14 @@
 //  Shared
 //
 //  Created by Delta on 24/5/22.
+//  Edited by Astra on 1/8/23.
 //
 
 import AVFoundation
 import SwiftUI
+
+var swipePreview = true;
+var chosenColor = 1.0;
 
 struct ContentView: View {
     var body: some View {
@@ -22,21 +26,25 @@ struct ContentView_Previews: PreviewProvider {
 
 struct CameraView: View{
     @State private var filtersPreview = [
-        FilterModel(filter: .circle, isPreview: true),
-        FilterModel(filter: .rectangle, isPreview: true),
-        FilterModel(filter: .lines, isPreview: true),
-        FilterModel(filter: .start, isPreview: true)
+        FilterModel(filter: .circle, isPreview: true, color: chosenColor),
+        FilterModel(filter: .rectangle, isPreview: true, color: abs(chosenColor - 1.0)),
+        FilterModel(filter: .lines, isPreview: true, color: abs(chosenColor - 1.0)),
+        FilterModel(filter: .start, isPreview: true, color: chosenColor)
     ]
     @StateObject var camera = CameraModel()
     @StateObject var viewModel = ViewModel()
     var body: some View{
+        let _ = print("test")
         GeometryReader { geometry in
             VStack{
                 ZStack(alignment: .center){
                     CameraPreview(camera: camera).ignoresSafeArea(.all, edges: .all
                     ).frame(width: geometry.size.width, alignment: .center)
-                    Filter(data: FilterModel(filter: viewModel.indexFilter, isPreview: false))
-                        .clipped()
+                    // this code adds the filter
+                    if (swipePreview) {
+                        Filter(data: FilterModel(filter: viewModel.indexFilter, isPreview: false, color: chosenColor))
+                            .clipped()
+                    }
                 }.onAppear {
                     camera.Check()
                 }.frame(width: geometry.size.width, height: geometry.size.height / 1.4, alignment: .center).clipped()
@@ -50,6 +58,28 @@ struct CameraView: View{
                   }
                 }.frame(height: Constant.sizeWidthPreview)
                 .background(Color.gray)
+                HStack(alignment: .center) {
+                    Button(action: {
+                        if chosenColor == 1.0 {
+                            chosenColor = 0.0
+                        } else {
+                            chosenColor = 1.0
+                        }
+                    }) {
+                        Text("Color Toggle")
+                        .padding(10)
+                        .foregroundColor(.white)
+                        .background(Color.pink)
+                    }
+                    Button(action: {
+                        swipePreview.toggle()
+                    }) {
+                        Text("Show/Hide Toggle")
+                        .padding(10)
+                        .foregroundColor(.white)
+                        .background(Color.pink)
+                    }
+                }
             }
         }
     }
@@ -62,6 +92,7 @@ struct TakePictureButton: View {
             HStack{
                 if isTaken {
                     Button(action: {}, label: {
+                        
                         //todo
                     })
                 }else{
@@ -169,5 +200,3 @@ struct CameraPreview: UIViewRepresentable {
         
     }
 }
-
-

--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -9,8 +9,8 @@
 import AVFoundation
 import SwiftUI
 
-var swipePreview = true;
-var chosenColor = 1.0;
+var swipePreview = true
+var chosenColor = 1.0
 
 struct ContentView: View {
     var body: some View {

--- a/Shared/FCircle.swift
+++ b/Shared/FCircle.swift
@@ -9,18 +9,20 @@ import SwiftUI
 
 struct FCircle: View{
     var isPreview = false
+    var color = 1.0
     var numShapes: Int
     
-    init(isPreview: Bool) {
+    init(isPreview: Bool, color: Double) {
         self.isPreview = isPreview
         self.numShapes = Constant.num / (isPreview ? 3 : 1)
+        self.color = color
     }
     
     var body: some View{
             ZStack(alignment: .center){
                 ForEach(Array(stride(from: 0, to: numShapes, by: 4)), id: \.self) { i in
                     Circle()
-                        .stroke(Color.white, lineWidth: Constant.borderWidth)
+                        .stroke(Color(white: color), lineWidth: Constant.borderWidth)
                     .frame(
                         width: Constant.minSizeShape + (CGFloat(i) * 4),
                         height: Constant.minSizeShape + (CGFloat(i) * 4),

--- a/Shared/FCircle.swift
+++ b/Shared/FCircle.swift
@@ -2,8 +2,8 @@
 //  FCircle.swift
 //  MoireLens (iOS)
 //
-//  Created by Delta on 11/7/22.
-//  Edited by Astra on 1/8/23.
+//  Created by Delta on 11/7/22
+//  Edited by Astra on 1/8/23
 //
 
 import SwiftUI

--- a/Shared/FCircle.swift
+++ b/Shared/FCircle.swift
@@ -3,7 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
-//  Edited by Astra on 1/8/22.
+//  Edited by Astra on 1/8/23.
 //
 
 import SwiftUI

--- a/Shared/FCircle.swift
+++ b/Shared/FCircle.swift
@@ -3,6 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
+//  Edited by Astra on 1/8/22.
 //
 
 import SwiftUI

--- a/Shared/FCircle.swift
+++ b/Shared/FCircle.swift
@@ -2,8 +2,8 @@
 //  FCircle.swift
 //  MoireLens (iOS)
 //
-//  Created by Delta on 11/7/22
-//  Edited by Astra on 1/8/23
+//  Created by Delta on 11/7/22.
+//  Edited by Astra on 1/8/23.
 //
 
 import SwiftUI

--- a/Shared/FLines.swift
+++ b/Shared/FLines.swift
@@ -3,7 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
-//  Edited by Astra on 1/8/22.
+//  Edited by Astra on 1/8/23.
 //
 
 import SwiftUI

--- a/Shared/FLines.swift
+++ b/Shared/FLines.swift
@@ -3,6 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
+//  Edited by Astra on 1/8/22.
 //
 
 import SwiftUI

--- a/Shared/FLines.swift
+++ b/Shared/FLines.swift
@@ -9,19 +9,19 @@ import SwiftUI
 
 struct FLines: View{
     var isPreview = false
+    var color = 0.0
     var scale: Int
-    
-    init(isPreview: Bool) {
+    init(isPreview: Bool, color: Double) {
         self.isPreview = isPreview
         self.scale = isPreview ? 3 : 5
+        self.color = color
     }
-    
     var body: some View{
         GeometryReader { geometry in
             HStack{
-                ForEach(0..<Constant.num) { i in
+                ForEach(0..<Constant.num, id: \.self) { i in
                         Rectangle()
-                        .fill(Color.black)
+                        .fill(Color(white: color))
                         .frame(
                             width: Constant.borderWidth,
                             height: geometry.size.height)

--- a/Shared/FReactangle.swift
+++ b/Shared/FReactangle.swift
@@ -3,7 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
-//  Edited by Astra on 1/8/22.
+//  Edited by Astra on 1/8/23.
 //
 
 import SwiftUI

--- a/Shared/FReactangle.swift
+++ b/Shared/FReactangle.swift
@@ -3,6 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
+//  Edited by Astra on 1/8/22.
 //
 
 import SwiftUI

--- a/Shared/FReactangle.swift
+++ b/Shared/FReactangle.swift
@@ -9,18 +9,20 @@ import SwiftUI
 
 struct FReactngle: View{
     var isPreview = false
+    var color = 0.0
     var numShapes: Int
     
-    init(isPreview: Bool) {
+    init(isPreview: Bool, color: Double) {
         self.isPreview = isPreview
         self.numShapes = Constant.num / (isPreview ? 3 : 1)
+        self.color = color
     }
     
     var body: some View{
         ZStack {
             ForEach(Array(stride(from: 0, to: numShapes, by: 4)), id: \.self) { i in
                 Rectangle()
-                    .stroke(Color.white, lineWidth: Constant.borderWidth)
+                    .stroke(Color(white: color), lineWidth: Constant.borderWidth)
                     .frame(
                         width: Constant.minSizeShape + (CGFloat(i) * 4),
                         height: Constant.minSizeShape + (CGFloat(i) * 4),

--- a/Shared/FStar.swift
+++ b/Shared/FStar.swift
@@ -9,18 +9,20 @@ import SwiftUI
 
 struct FStart: View{
     var isPreview = false
+    var color = 1.0
     var scale: Int
     
-    init(isPreview: Bool) {
+    init(isPreview: Bool, color: Double) {
         self.isPreview = isPreview
         self.scale = Constant.num
+        self.color = color
     }
     
     var body: some View{
         ZStack{
-            ForEach(0..<scale * 5) { i in
+            ForEach(0..<scale * 5, id: \.self) { i in
                 Rectangle()
-                    .fill(Color.white)
+                    .fill(Color(white: color))
                     .frame(width: Constant.borderWidth, height: 1000)
                     .rotationEffect(Angle(degrees: Double(90 + (i * 5)) ))
             }

--- a/Shared/FStar.swift
+++ b/Shared/FStar.swift
@@ -3,7 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
-//  Edited by Astra on 1/8/22.
+//  Edited by Astra on 1/8/23.
 //
 
 import SwiftUI

--- a/Shared/FStar.swift
+++ b/Shared/FStar.swift
@@ -3,6 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
+//  Edited by Astra on 1/8/22.
 //
 
 import SwiftUI

--- a/Shared/Filter.swift
+++ b/Shared/Filter.swift
@@ -3,7 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
-//  Edited by Astra on 1/8/22.
+//  Edited by Astra on 1/8/23.
 //
 
 import SwiftUI

--- a/Shared/Filter.swift
+++ b/Shared/Filter.swift
@@ -3,6 +3,7 @@
 //  MoireLens (iOS)
 //
 //  Created by Delta on 11/7/22.
+//  Edited by Astra on 1/8/22.
 //
 
 import SwiftUI
@@ -26,13 +27,13 @@ struct Filter: View {
             } label: {
                 switch data.filter {
                 case .circle:
-                    FCircle(isPreview: data.isPreview)
+                    FCircle(isPreview: data.isPreview, color: data.color)
                 case .rectangle:
-                    FReactngle(isPreview: data.isPreview)
+                    FReactngle(isPreview: data.isPreview, color: data.color)
                 case .lines:
-                    FLines(isPreview: data.isPreview)
+                    FLines(isPreview: data.isPreview, color: data.color)
                 case .start:
-                    FStart(isPreview: data.isPreview)
+                    FStart(isPreview: data.isPreview, color: data.color)
                 }
             }.frame(width: geometry.size.width, height: geometry.size.height, alignment: .center)
         }

--- a/Shared/Filter.swift
+++ b/Shared/Filter.swift
@@ -2,8 +2,8 @@
 //  Filter.swift
 //  MoireLens (iOS)
 //
-//  Created by Delta on 11/7/22.
-//  Edited by Astra on 1/8/23.
+//  Created by Delta on 11/7/22
+//  Edited by Astra on 1/8/23
 //
 
 import SwiftUI

--- a/Shared/Model.swift
+++ b/Shared/Model.swift
@@ -2,8 +2,8 @@
 //  Model.swift
 //  MoireLens
 //
-//  Created by Delta on 13/6/22.
-//  Edited by Astra on 1/8/23.
+//  Created by Delta on 13/6/22
+//  Edited by Astra on 1/8/23
 //
 
 import Foundation

--- a/Shared/Model.swift
+++ b/Shared/Model.swift
@@ -3,6 +3,7 @@
 //  MoireLens
 //
 //  Created by Delta on 13/6/22.
+//  Edited by Astra on 1/8/23.
 //
 
 import Foundation
@@ -10,4 +11,5 @@ import Foundation
 struct FilterModel {
     var filter: FILTERS
     var isPreview: Bool
+    var color: Double
 }

--- a/addition
+++ b/addition
@@ -1,0 +1,1 @@
+System.out.println("Hello World!");

--- a/addition
+++ b/addition
@@ -1,1 +1,9 @@
-System.out.println("Hello World!");
+public class Main {
+  public static void main(String[] args) {
+    int sum = 0;
+    for (int i = 1; i <= 5; i++) {
+      sum = sum + i;
+    }  
+    System.out.println(sum);
+  }
+}


### PR DESCRIPTION
I adjusted the code to create two buttons: one for hiding or showing the filters, and another for changing the filter's color. The original issue 13 asked for a swipe, but not only would a swipe conflict with photo capturing, but it would also be harder to implement in SwiftUI. The buttons change all of the filters at once to the same visibility or color. The only problem with my code is that the changes don't apply to the current filter. I can fix those later, but right now I'm going to focus on the gitignore or camera functionality. Use the most recent versions of each file if possible, but all of the updates work.